### PR TITLE
pinned flask-jwt-extended

### DIFF
--- a/{{cookiecutter.project_name}}/requirements.txt
+++ b/{{cookiecutter.project_name}}/requirements.txt
@@ -4,7 +4,7 @@ flask-restful
 flask-migrate
 flask-sqlalchemy
 flask-marshmallow
-flask-jwt-extended
+flask-jwt-extended==3.25.1
 marshmallow-sqlalchemy
 python-dotenv
 passlib


### PR DESCRIPTION
flask-jwt-extended 4.0 introduced breaking changes which will require a refactor (not yet analyzed)

Pinning the dependency is recommended until the changes are made; I may follow with another PR with those changes unless they are already in flight